### PR TITLE
WIP: Add initial janky date parsing support for Windows PowerShell

### DIFF
--- a/PSNeo4j/PSNeo4j.ConfigSchema.ps1
+++ b/PSNeo4j/PSNeo4j.ConfigSchema.ps1
@@ -23,4 +23,8 @@
         Type = [string]
         Default = 'Neo4j'
     }
+    ParseDate = @{
+        Type = [string]
+        Default = 'NoParse'
+    }
 }

--- a/PSNeo4j/PSNeo4j.psm1
+++ b/PSNeo4j/PSNeo4j.psm1
@@ -60,5 +60,6 @@ catch {
 finally {
     $PSNeo4jConfig = Initialize-PSNeo4jConfiguration -Passthru -ConfigSchema $ConfigSchema -UpdateConfig $False
 }
+$DatesConverted = ( ConvertFrom-JSON -InputObject '{"string":"/Date(1526867499647)/"}' ).string -is [DateTime]
 
 Export-ModuleMember -Function $Public.Basename

--- a/PSNeo4j/Private/Parse-Neo4jDate.ps1
+++ b/PSNeo4j/Private/Parse-Neo4jDate.ps1
@@ -1,0 +1,24 @@
+function Parse-Neo4jDate {
+    param($DateString)
+    if($DateString -notmatch '/Date\(\d+\)/') {
+        return $DateString
+    }
+    $UnixDate = $DateString -replace '\D+'
+    if($UnixDate){
+        try {
+            $UnixTime = [int]$UnixDate
+        }
+        catch {
+            $UnixTime = [int]$($UnixDate -replace ".{3}$") # Replace last 3 chars, milliseconds
+        }
+        try {
+            [timezone]::CurrentTimeZone.ToLocalTime( ([datetime]'1/1/1970').AddSeconds($UnixTime) )
+        }
+        catch {
+            $UnixTime
+        }
+    }
+    else {
+        $DateString
+    }
+}

--- a/PSNeo4j/Public/Invoke-Neo4jQuery.ps1
+++ b/PSNeo4j/Public/Invoke-Neo4jQuery.ps1
@@ -102,7 +102,10 @@
 
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential =  $PSNeo4jConfig.Credential
+        $Credential =  $PSNeo4jConfig.Credential,
+
+        [validateset('NoParse', 'ByKeyword', 'ByValue')]
+        [string]$ParseDate = $PSNeo4jConfig.ParseDate
     )
     begin {
         if($PSCmdlet.ParameterSetName -eq 'Query') {
@@ -137,7 +140,7 @@
         Write-Verbose "$($Params | Format-List | Out-String)"
         $Response = $null
         $Response = Invoke-RestMethod @Params
-        $ConvertParams = . Get-ParameterValues -BoundParameters $PSBoundParameters -Invocation $MyInvocation -Properties MetaProperties, MergePrefix, As
+        $ConvertParams = . Get-ParameterValues -BoundParameters $PSBoundParameters -Invocation $MyInvocation -Properties MetaProperties, MergePrefix, As, ParseDate
         Write-Verbose "Params is $($ConvertParams | Format-List | Out-String)"
         ConvertFrom-Neo4jResponse @ConvertParams -Response $Response
     }

--- a/PSNeo4j/Public/Set-PSNeo4jConfiguration.ps1
+++ b/PSNeo4j/Public/Set-PSNeo4jConfiguration.ps1
@@ -60,6 +60,13 @@
 
         We default to the value specified by Set-PSNeo4jConfiguration (Initially, neo4j:neo4j)
 
+    .PARAMETER ParseDate
+        On Windows PowerShell, whether to inspect objects and attempt to parse properties that look like dates (e.g. '/Date(1526867499647)/')
+
+        NoParse:   Don't parse.  Faster
+        ByKeyword: Parse properties with 'Date' or 'Time' in their name
+        ByValue:   Parse properties with value matching something like '/Date(1526867499647)/'
+
     .FUNCTIONALITY
         Neo4j
     #>
@@ -76,6 +83,8 @@
         [validateset('id', 'type', 'deleted')]
         [string[]]$MetaProperties,
         [string]$MergePrefix,
+        [validateset('NoParse', 'ByKeyword', 'ByValue')]
+        [string]$ParseDate,
 
         [ValidateSet("User", "Machine", "Enterprise")]
         [string]$Scope = "User",


### PR DESCRIPTION
This PR adds the ability to inspect objects to convert property values that look like dates by adding `ParseDate` parameters and module configuration values.

For example:

```json
{
  "SomeProperty": "/Date(1526867499647)/"
}
```

This works without issue in PowerShell Core (Newtonsoft.Json seems to handle this automatically)
