### PR TITLE
Allow parsing dates in a format Neo4j likes

### DIFF
--- a/PSNeo4j/PSNeo4j.ConfigSchema.ps1
+++ b/PSNeo4j/PSNeo4j.ConfigSchema.ps1
@@ -27,4 +27,12 @@
         Type = [string]
         Default = 'NoParse'
     }
+    ParseDatePatterns = @{
+        Type = [string[]]
+        Default = 'DateTimeO', 'DateWithEpochMs'
+    }
+    ParseDateInput = @{
+        Type = [System.Boolean]
+        Default = $True
+    }
 }

--- a/PSNeo4j/PSNeo4j.psd1
+++ b/PSNeo4j/PSNeo4j.psd1
@@ -4,7 +4,7 @@
 RootModule = 'PSNeo4j.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.30'
+ModuleVersion = '0.1.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -99,7 +99,7 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        # ReleaseNotes = ''
+        ReleaseNotes = 'Added date parsing consistent with "Get-Date -Format o" for input and output'
 
     } # End of PSData hashtable
 

--- a/PSNeo4j/PSNeo4j.psm1
+++ b/PSNeo4j/PSNeo4j.psm1
@@ -4,14 +4,11 @@
     $ModuleRoot = $PSScriptRoot
 
 #Dot source the files
-Foreach($import in @($Public + $Private))
-{
-    Try
-    {
+Foreach($import in @($Public + $Private)) {
+    Try {
         . $import.fullname
     }
-    Catch
-    {
+    Catch {
         Write-Error -Message "Failed to import function $($import.fullname): $_"
     }
 }

--- a/PSNeo4j/Private/ConvertTo-Neo4jDateTime.ps1
+++ b/PSNeo4j/Private/ConvertTo-Neo4jDateTime.ps1
@@ -1,0 +1,23 @@
+﻿# I dont do much validation.  I expect a hash, or an object with settable properties
+# Converts any key/property value that is a datetime into an iso8601/neo4j datetime string
+function ConvertTo-Neo4jDateTime {
+    param(
+        $InputObject,
+        [switch]$ParseDateInput = $PSNeo4jConfig.ParseDateInput
+    )
+    if(-not $ParseDateInput){
+        return $InputObject
+    }
+    if($InputObject -is [hashtable]){
+        $Properties = $($InputObject.Keys)
+    }
+    else{
+        $Properties = $InputObject.PSObject.Properties.Name
+    }
+    foreach($Property in $Properties){
+        if($InputObject.$Property -is [datetime]) {
+            $InputObject.$Property = $InputObject.$Property.ToString('o')
+        }
+    }
+    $InputObject
+}

--- a/PSNeo4j/Private/Parse-Neo4jDate.ps1
+++ b/PSNeo4j/Private/Parse-Neo4jDate.ps1
@@ -1,24 +1,42 @@
 function Parse-Neo4jDate {
-    param($DateString)
-    if($DateString -notmatch '/Date\(\d+\)/') {
-        return $DateString
+    [cmdletbinding()]
+    param(
+        $DateString,
+        [validateset('DateWithEpochMs', 'DateTimeO')]
+        [string[]]$ParseDatePatterns = $PSNeo4jConfig.ParseDatePatterns
+    )
+    # Get-Date -Format o should return a compatible string for this
+    # This should be the preferred method, given that this string allows datatime use in Neo4j
+    if($ParseDatePatterns -contains 'DateTimeO' -and $DateString -match "^\d{4}-\d{2}-\d{2}t\d{2}" ){
+        try {
+            Get-Date $DateString -ErrorAction Stop
+        }
+        catch {
+            return $DateString
+        }
     }
-    $UnixDate = $DateString -replace '\D+'
-    if($UnixDate){
-        try {
-            $UnixTime = [int]$UnixDate
+    # Try to avoid this.  Instead of ingesting output from Get-Date, use Get-Date -Format o
+    elseif($ParseDatePatterns -contains 'DateWithEpochMs' -and $DateString -match '/Date\(\d+\)/'){
+        $UnixDate = $DateString -replace '\D+'
+        if($UnixDate){
+            try {
+                $UnixTime = [int]$UnixDate
+            }
+            catch {
+                $UnixTime = [int]$($UnixDate -replace ".{3}$") # Replace last 3 chars, milliseconds
+            }
+            try {
+                return [timezone]::CurrentTimeZone.ToLocalTime( ([datetime]'1/1/1970').AddSeconds($UnixTime) )
+            }
+            catch {
+                $UnixTime
+            }
         }
-        catch {
-            $UnixTime = [int]$($UnixDate -replace ".{3}$") # Replace last 3 chars, milliseconds
-        }
-        try {
-            [timezone]::CurrentTimeZone.ToLocalTime( ([datetime]'1/1/1970').AddSeconds($UnixTime) )
-        }
-        catch {
-            $UnixTime
+        else {
+            return $DateString
         }
     }
     else {
-        $DateString
+        return $DateString
     }
 }

--- a/PSNeo4j/Public/ConvertFrom-Neo4jResponse.ps1
+++ b/PSNeo4j/Public/ConvertFrom-Neo4jResponse.ps1
@@ -135,7 +135,7 @@
                             $Datum = [pscustomobject]$Datum
                         }
                         if(-not $Script:DatesConverted -and 'ByKeyword', 'ByValue' -contains $ParseDate) {
-
+                            
                             if($ParseDate -eq 'ByKeyword') {
                                 $ParseProps = $Datum.psobject.properties.name.where({$_ -match 'Date|Time'})
                             }
@@ -144,7 +144,7 @@
                             }
                             if($ParseProps.count -gt 0) {
                                 foreach($ParseProp in $ParseProps){
-                                    $Datum.$ParseProp = Parse-Neo4jDate -DateString $Datum.$ParseProp
+                                    $Datum.$ParseProp = Parse-Neo4jDate -DateString $Datum.$ParseProp -ParseDatePatterns $PSNeo4jConfig.ParseDatePatterns
                                 }
                             }
                         }
@@ -207,7 +207,7 @@
                             }
                             if($ParseProps.count -gt 0) {
                                 foreach($ParseProp in $ParseProps){
-                                    $Datum.$ParseProp = Parse-Neo4jDate -DateString $Datum.$ParseProp
+                                    $Datum.$ParseProp = Parse-Neo4jDate -DateString $Datum.$ParseProp -ParseDatePatterns $PSNeo4jConfig.ParseDatePatterns
                                 }
                             }
                         }

--- a/PSNeo4j/Public/ConvertTo-Neo4jNodeStatement.ps1
+++ b/PSNeo4j/Public/ConvertTo-Neo4jNodeStatement.ps1
@@ -34,8 +34,11 @@
     param(
         [string[]]$Label,
         [object]$Props,
-        [switch]$Passthru
+        [switch]$Passthru,
+
+        [switch]$ParseDateInput = $PSNeo4jConfig.ParseDateInput
     )
+    $Props = ConvertTo-Neo4jDateTime $Props -ParseDateInput $ParseDateInput
     $LabelString = $Label -join ':'
     $Query = "CREATE (node:$LabelString { props } )"
     if($Passthru) {$Query = "$Query RETURN node"}

--- a/PSNeo4j/Public/ConvertTo-Neo4jNodesStatement.ps1
+++ b/PSNeo4j/Public/ConvertTo-Neo4jNodesStatement.ps1
@@ -41,7 +41,9 @@ function ConvertTo-Neo4jNodesStatement {
         [string[]]$Label,
         [parameter(ValueFromPipeline=$True)]
         [object[]]$InputObject,
-        [switch]$Passthru
+        [switch]$Passthru,
+
+        [switch]$ParseDateInput = $PSNeo4jConfig.ParseDateInput
     )
     begin {
         $LabelString = $Label -join ':'
@@ -51,6 +53,7 @@ function ConvertTo-Neo4jNodesStatement {
     }
     process {
         foreach($Item in $InputObject) {
+            $Item = ConvertTo-Neo4jDateTime $Item -ParseDateInput $ParseDateInput
             [void]$Props.add($Item)
         }
     }

--- a/PSNeo4j/Public/Invoke-Neo4jQuery.ps1
+++ b/PSNeo4j/Public/Invoke-Neo4jQuery.ps1
@@ -109,7 +109,9 @@
         $Credential =  $PSNeo4jConfig.Credential,
 
         [validateset('NoParse', 'ByKeyword', 'ByValue')]
-        [string]$ParseDate = $PSNeo4jConfig.ParseDate
+        [string]$ParseDate = $PSNeo4jConfig.ParseDate,
+
+        [switch]$ParseDateInput = $PSNeo4jConfig.ParseDateInput
     )
     begin {
         if($PSCmdlet.ParameterSetName -eq 'Query') {
@@ -126,6 +128,9 @@
                     statement = $QueryString
                 }
                 if($PSBoundParameters.ContainsKey('Parameters')) {
+                    if($ParseDateInput){
+                        $Parameters = ConvertTo-Neo4jDateTime $Parameters -ParseDateInput $ParseDateInput
+                    }
                     Add-Member -InputObject $Statement -Name 'parameters' -Value $Parameters -MemberType NoteProperty
                 }
                 if($AsGraph.IsPresent) {

--- a/PSNeo4j/Public/New-Neo4jNode.ps1
+++ b/PSNeo4j/Public/New-Neo4jNode.ps1
@@ -98,13 +98,16 @@
 
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential =  $PSNeo4jConfig.Credential
+        $Credential =  $PSNeo4jConfig.Credential,
+
+        [switch]$ParseDateInput = $PSNeo4jConfig.ParseDateInput
     )
     begin {
         $Objects = [System.Collections.ArrayList]@()
     }
     process {
         foreach($Object in $InputObject) {
+            $Object = ConvertTo-Neo4jDateTime $Object -ParseDateInput $ParseDateInput
             [void]$Objects.add($Object)
         }
     }

--- a/PSNeo4j/Public/New-Neo4jRelationship.ps1
+++ b/PSNeo4j/Public/New-Neo4jRelationship.ps1
@@ -194,13 +194,16 @@
 
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential =  $PSNeo4jConfig.Credential
+        $Credential =  $PSNeo4jConfig.Credential,
+
+        [switch]$ParseDateInput = $PSNeo4jConfig.ParseDateInput
     )
     $SQLParams = @{}
 
     if($PSCmdlet.ParameterSetName -eq 'LabelHash') {
         $LeftPropString = $null
         if($LeftHash.keys.count -gt 0) {
+            $LeftHash = ConvertTo-Neo4jDateTime $LeftHash -ParseDateInput $ParseDateInput
             $Props = foreach($Property in $LeftHash.keys) {
                 "$Property`: `$left$Property"
                 $SQLParams.Add("left$Property", $LeftHash[$Property])
@@ -215,6 +218,7 @@
 
         $RightPropString = $null
         if($RightHash.keys.count -gt 0) {
+            $RightHash = ConvertTo-Neo4jDateTime $RightHash -ParseDateInput $ParseDateInput
             $Props = foreach($Property in $RightHash.keys) {
                 "$Property`: `$right$Property"
                 $SQLParams.Add("right$Property", $RightHash[$Property])
@@ -235,6 +239,7 @@
     $InvokeParams = @{}
     $PropString = $null
     if($Properties) {
+        $Properties = ConvertTo-Neo4jDateTime $Properties -ParseDateInput $ParseDateInput
         $Props = foreach($Property in $Properties.keys) {
             "$Property`: `$relationship$Property"
             $SQLParams.Add("relationship$Property", $Properties[$Property])
@@ -243,6 +248,7 @@
         $PropString = "{$PropString}"
     }
     if($PSBoundParameters.ContainsKey('Parameters')) {
+        $Parameters = ConvertTo-Neo4jDateTime $Parameters -ParseDateInput $ParseDateInput
         foreach($Property in $Parameters.keys) {
             $SQLParams.Add("$Property", $Parameters[$Property])
         }

--- a/PSNeo4j/Public/Set-Neo4jNode.ps1
+++ b/PSNeo4j/Public/Set-Neo4jNode.ps1
@@ -107,12 +107,15 @@
 
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential =  $PSNeo4jConfig.Credential
+        $Credential =  $PSNeo4jConfig.Credential,
+
+        [switch]$ParseDateInput = $PSNeo4jConfig.ParseDateInput
     )
     begin {
         $Queries = [System.Collections.ArrayList]@()
         $SQLParams = @{}
         $InvokeParams = @{}
+        $InputObject = ConvertTo-Neo4jDateTime $InputObject -ParseDateInput $ParseDateInput
         if($InputObject -is [hashtable]) {
             $PropsToUpdate = $InputObject.Keys
         }
@@ -130,7 +133,8 @@
         # We need three parameterized property strings: for MERGE (the identifying bits), ON CREATE SET (all the bits), ON MATCH SET (the bits to update)
         foreach($PropHash in $Hash) {
             $MergePropString = $null
-            if($Hash.keys.count -gt 0) {
+            if($PropHash.keys.count -gt 0) {
+                $PropHash = ConvertTo-Neo4jDateTime $PropHash -ParseDateInput $ParseDateInput
                 [string[]]$MergeProps = foreach($Property in $PropHash.keys) {
                     "$Property`: `$merge$Count$Property"
                     $SQLParams.Add("merge$Count$Property", $PropHash[$Property])

--- a/PSNeo4j/Public/Set-PSNeo4jConfiguration.ps1
+++ b/PSNeo4j/Public/Set-PSNeo4jConfiguration.ps1
@@ -67,6 +67,21 @@
         ByKeyword: Parse properties with 'Date' or 'Time' in their name
         ByValue:   Parse properties with value matching something like '/Date(1526867499647)/'
 
+    .PARAMETER ParseDatePatterns
+        How to parse properties that might be dates, if ParseDate is configured
+
+        DateTimeO:       Parse properties with value in a format consistent with Get-Date -Format o (e.g. 2019-08-07T23:50:03.1734728-04:00)
+        DateWithEpochMs: Parse properties with value in a format consistent with '/Date(1526867499647)/'
+
+        Defaults to DateTimeO, DateWithEpochMS.  Not parsing, or parsing a single pattern may offer a small improvement to performance
+
+    .PARAMETER ParseDateInput
+        If specified, convert any datetime property on every object (nodes, relationships) to the format consistent with Get-Date -Format o
+
+        This allows Neo4j to parse the string as a DateTime in queries
+
+        Defaults to $True
+
     .FUNCTIONALITY
         Neo4j
     #>
@@ -85,6 +100,9 @@
         [string]$MergePrefix,
         [validateset('NoParse', 'ByKeyword', 'ByValue')]
         [string]$ParseDate,
+        [validateset('DateWithEpochMs', 'DateTimeO')]
+        [string[]]$ParseDatePatterns,
+        [bool]$ParseDateInput,
 
         [ValidateSet("User", "Machine", "Enterprise")]
         [string]$Scope = "User",
@@ -103,6 +121,8 @@
         'MetaProperties' { $Script:PSNeo4jConfig.MetaProperties = $MetaProperties }
         'MergePrefix' { $Script:PSNeo4jConfig.MergePrefix = $MergePrefix }
         'ParseDate' { $Script:PSNeo4jConfig.ParseDate = $ParseDate }
+        'ParseDateInput' { $Script:PSNeo4jConfig.ParseDateInput = $ParseDateInput }
+        'ParseDatePatterns' { $Script:PSNeo4jConfig.ParseDatePatterns = $ParseDatePatterns }
     }
 
     if($UpdateConfig)


### PR DESCRIPTION
* `PSNeo4jConfig.ParseDatePatterns` controls output parsing patterns
* `PSNeo4jConfig.ParseDateInput` converts all datetime input

Previously we did nothing to inputs, and assumed outputs were formatted as if you simply sent the output of `Get-Date`, resulting in a string like `/Date(1526867499647)`.  Parseable, and `ConvertFrom-Json` in PowerShell Core likes it, but in Neo4j, pretty much useless.

Going forward, `PSNeo4jConfig.ParseDateInput` determines whether we parse every object for properties that are `datetime`s, and if we find those, we run them through `Get-Date -Format o` to get them into a format that Neo4j _does_ know how to process as a `datetime`

We also added `PSNeo4jConfig.ParseDatePatterns` to allow folks to specify parsing output date fields in the old format, in the new format, or to try both ways.

This is a breaking change as all input will process `datetime` fields into the new format by default.  Bumped the minor version because (1) not ready for version 1.0.0, and (2) does anyone actually use this and (3), if they do, they should gate the version they use : )

Will merge this tonight if I don't hear back!